### PR TITLE
pc - update .travis.yml to fix bundler fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
   - 2.5.3
+before_install:
+  - gem update --system
+  - gem install bundler
 script: "bundle exec jekyll build"


### PR DESCRIPTION
This change to the .travis.yml helps to address this problem that occurs on TravisCI:

```
$ bundle install --jobs=3 --retry=3 --deployment
Traceback (most recent call last):
	4: from /home/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `<main>'
	3: from /home/travis/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:15:in `eval'
	2: from /home/travis/.rvm/gems/ruby-2.5.1/bin/bundle:23:in `<main>'
	1: from /home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
/home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
The command "eval bundle install --jobs=3 --retry=3 --deployment " failed. Retrying, 2 of 3.
```